### PR TITLE
Fix incompatibility with mastermind semver causing build break.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,35 +2,46 @@
 
 
 [[projects]]
+  digest = "1:f313598719f69ec4edbcd75b0f2ef1c8ed9e00f6ff3d7583ac3966db2d70d326"
   name = "github.com/Masterminds/semver"
   packages = ["."]
-  revision = "15d8430ab86497c5c0da827b748823945e1cf1e1"
-  version = "v1.4.0"
+  pruneopts = "UT"
+  revision = "910aa146bd66780c2815d652b92a7fc5331e533c"
+  version = "v3.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:315c5f2f60c76d89b871c73f9bd5fe689cad96597afd50fb9992228ef80bdd34"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
-    "parse"
+    "parse",
   ]
+  pruneopts = "UT"
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
   branch = "master"
+  digest = "1:c198fdc381e898e8fb62b8eb62758195091c313ad18e52a3067366e1dda2fb3c"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
+  digest = "1:c06d9e11d955af78ac3bbb26bd02e01d2f61f689e1a3bce2ef6fb683ef8a7f2d"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8902019bb610aa722dcb10123eb9371a198e21114496d7e957cdb79507940e77"
+  input-imports = [
+    "github.com/Masterminds/semver",
+    "gopkg.in/alecthomas/kingpin.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/Masterminds/semver"
-  version = "^1.4.0"
+  version = "^3.0.3"
 
 [[constraint]]
   name = "gopkg.in/alecthomas/kingpin.v2"

--- a/main.go
+++ b/main.go
@@ -128,11 +128,11 @@ func main() {
 		var component string
 		switch *getComponent {
 		case "major":
-			component = strconv.FormatInt(v.Major(), 10)
+			component = strconv.FormatUint(v.Major(), 10)
 		case "minor":
-			component = strconv.FormatInt(v.Minor(), 10)
+			component = strconv.FormatUint(v.Minor(), 10)
 		case "patch":
-			component = strconv.FormatInt(v.Patch(), 10)
+			component = strconv.FormatUint(v.Patch(), 10)
 		case "prerelease":
 			component = v.Prerelease()
 		case "metadata":


### PR DESCRIPTION
Fixs the build break:

```
go get -v github.com/davidrjonas/semver-cli                  
github.com/alecthomas/units
github.com/alecthomas/template/parse
github.com/Masterminds/semver
github.com/alecthomas/template
gopkg.in/alecthomas/kingpin.v2
github.com/davidrjonas/semver-cli
# github.com/davidrjonas/semver-cli
../../github.com/davidrjonas/semver-cli/main.go:131:41: cannot use v.Major() (type uint64) as type int64 in argument to strconv.FormatInt
../../github.com/davidrjonas/semver-cli/main.go:133:41: cannot use v.Minor() (type uint64) as type int64 in argument to strconv.FormatInt
../../github.com/davidrjonas/semver-cli/main.go:135:41: cannot use v.Patch() (type uint64) as type int64 in argument to strconv.FormatInt
```

- Update dep dependency
- Change `strconv.FormatInt()` to `strconv.FormatUint()`